### PR TITLE
Get proper name for 'literal-like' properties ('aria-property')

### DIFF
--- a/src/parseProps.js
+++ b/src/parseProps.js
@@ -6,6 +6,11 @@ let isRequired = pt => t.isMemberExpression(pt) && pt.property.name === 'isRequi
 
 let raw = (node, src) => src.slice(node.start, node.end).toString()
 
+function getKeyName(pt) {
+  if (pt.key.type === 'Literal') return pt.key.value; // 'aria-property'
+  else return pt.key.name;
+}
+
 function parsePropTypes(node, rslt = { props: {}, composes: [] }, scope) {
   var props = rslt.props;
 
@@ -19,10 +24,11 @@ function parsePropTypes(node, rslt = { props: {}, composes: [] }, scope) {
         rslt.composes.push(name)
     }
     else {
-      props[pt.key.name] = props[pt.key.name] || {}
+      const keyName = getKeyName(pt);
+      props[keyName] = props[keyName] || {}
 
-      props[pt.key.name] = {
-        ...props[pt.key.name],
+      props[keyName] = {
+        ...props[keyName],
         type: getTypeFromPropType(pt.value),
         required: isRequired(pt.value),
         desc: doc.parseCommentBlock(pt) || ''
@@ -94,8 +100,9 @@ module.exports = {
   parseDefaultProps(node, rslt = {}, src) {
     node && node.properties && node.properties
       .forEach( pt => {
-        rslt[pt.key.name] = rslt[pt.key.name] || {}
-        rslt[pt.key.name].defaultValue = raw(pt.value, src)
+        const keyName = getKeyName(pt);
+        rslt[keyName] = rslt[keyName] || {}
+        rslt[keyName].defaultValue = raw(pt.value, src)
       })
       return rslt
   }

--- a/test/fixtures/class-assigned.js
+++ b/test/fixtures/class-assigned.js
@@ -11,6 +11,7 @@ class AssignedComponent extends React.Component {
 }
 
 AssignedComponent.defaultProps = {
+  'aria-property': 'aria-value',
   stringProp: 'form',
   boolProp: true,
   funcProp: (path, model) => getter(path)(model),
@@ -34,6 +35,8 @@ AssignedComponent.propTypes = {
     stringProp: React.PropTypes.string,
 
     boolProp:   React.PropTypes.bool,
+
+    'aria-property': React.PropTypes.string,
 
     enumProp:   React.PropTypes.oneOf([true, 'john', 5]),
 

--- a/test/fixtures/class-static.js
+++ b/test/fixtures/class-static.js
@@ -7,6 +7,7 @@ var React  = require('react');
 class StaticComponent extends React.Component {
 
   static defaultProps = {
+    'aria-property': 'aria-value',
     stringProp: 'form',
     boolProp: true,
     funcProp: (path, model) => getter(path)(model),
@@ -30,6 +31,8 @@ class StaticComponent extends React.Component {
     stringProp: React.PropTypes.string,
 
     boolProp:   React.PropTypes.bool,
+
+    'aria-property': React.PropTypes.string,
 
     enumProp:   React.PropTypes.oneOf([true, 'john', 5]),
 

--- a/test/fixtures/create-class.js
+++ b/test/fixtures/create-class.js
@@ -8,6 +8,7 @@ var ClassicComponent = React.createClass({
 
   getDefaultProps(){
     return {
+      'aria-property': 'aria-value',
       stringProp: 'form',
       boolProp: true,
       funcProp: (path, model) => getter(path)(model),
@@ -16,7 +17,6 @@ var ClassicComponent = React.createClass({
   },
 
   propTypes:  {
-
     /**
      * An object hash of field errors for the form.
      */
@@ -32,6 +32,8 @@ var ClassicComponent = React.createClass({
     stringProp: React.PropTypes.string,
 
     boolProp:   React.PropTypes.bool,
+
+    'aria-property': React.PropTypes.string,
 
     enumProp:   React.PropTypes.oneOf([true, 'john', 5]),
 

--- a/test/fixtures/mixins.js
+++ b/test/fixtures/mixins.js
@@ -2,6 +2,7 @@
 var React  = require('react');
 
 var defaults = {
+      'aria-property': 'aria-value',
       stringProp: 'form',
       boolProp: true,
       funcProp: (path, model) => getter(path)(model),
@@ -25,6 +26,8 @@ var props = {
     stringProp: React.PropTypes.string,
 
     boolProp:   React.PropTypes.bool,
+
+    'aria-property': React.PropTypes.string,
 
     enumProp:   React.PropTypes.oneOf([true, 'john', 5]),
 

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -4,6 +4,12 @@ var { types: t } = require('babel-core')
 describe('parsing Components', () => {
 
   var propMetaData = {
+        'aria-property': {
+          type: { name: 'string' },
+          required: false,
+          desc: '',
+          defaultValue: '\'aria-value\''
+        },
         objProp: {
           type: { name: 'object' },
           required: false,
@@ -250,4 +256,3 @@ describe('parsing Components', () => {
   })
 
 })
-


### PR DESCRIPTION
When property key is of type 'Literal',
it has no 'name' key, then we should use 'value' key instead.

```
pt.key: { type: 'Literal',
  start: 348,
  end: 363,
  loc:
   { start: { line: 20, column: 4 },
     end: { line: 20, column: 19 } },
  value: 'aria-property',
  rawValue: 'aria-property',
  raw: '\'aria-property\''
}
```

Fixes: #1
